### PR TITLE
BREAKING CHANGE: token refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2430,6 +2430,12 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.1.tgz",
+      "integrity": "sha512-TBZ6YdX7IZz4U9/mBoB8zCMRN1vXw8QdihRcZxD3I0Cv/r8XF8RggZ8WiXFws4aj5atzRR5hJrYer7g8nXwpnQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.12.42",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@testing-library/user-event": "^7.2.1",
     "@types/jest": "^25.1.4",
     "@types/jwt-decode": "^2.2.1",
+    "@types/mocha": "^8.0.1",
     "@types/node": "^12.12.38",
     "@types/react": "^16.9.27",
     "@types/react-dom": "^16.9.7",


### PR DESCRIPTION
This pull request fixes: https://github.com/gardner/react-oauth2-pkce/issues/3

Other breaking changes:

* autoRefresh is enabled by default
* refreshSlack has been reduced from 10 to 5 seconds
* refreshSlack is added to the time, instead of subtracted from it