### PR TITLE
New refresh_token is optional after renewal

### DIFF
--- a/src/AuthService.ts
+++ b/src/AuthService.ts
@@ -220,7 +220,10 @@ export class AuthService<TIDToken = JWTIDToken> {
       body: toUrlEncoded(payload)
     })
     this.removeItem('pkce')
-    const json = await response.json()
+    let json = await response.json()
+    if (isRefresh && !json.refresh_token) {
+      json.refresh_token = payload.refresh_token
+    }
     this.setAuthTokens(json as AuthTokens)
     if (autoRefresh) {
       this.startTimer()


### PR DESCRIPTION
While renewing access token, RFC6749 states that receiving new refresh token is optional. If that's the case, keep an old refresh token (AWS Cognito does not send one).