### PR TITLE
Added possibility to end user session on "Single Application Logout".

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ export default App
 
 ### Custom Provider/Endpoint
 
-After https://github.com/gardner/react-oauth2-pkce/pull/16 it is possible to pass in just `provider` or `authorizeEndpoint` and `tokenEndpoint`. These two parameters were added to maintain backwards compatibility while enabling callers to customize the endpoint.
+After https://github.com/gardner/react-oauth2-pkce/pull/16 it is possible to pass in just `provider` or `authorizeEndpoint`, `tokenEndpoint` and `logoutEndpoint`. These two parameters were added to maintain backwards compatibility while enabling callers to customize the endpoint.
+
+### End User Session on "Single Application Logout"
+You can end user session when calling `logout(true)`. A custom endpoint can configured by passing `logoutEndpoint` as props. The user will be redirected to the `redirectUri`.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-pkce",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Authenticate against generic OAuth2 using PKCE",
   "author": "Gardner Bickford <gardner@bickford.nz>",
   "license": "MIT",

--- a/src/AuthService.ts
+++ b/src/AuthService.ts
@@ -12,6 +12,7 @@ export interface AuthServiceProps {
   provider: string
   authorizeEndpoint?: string
   tokenEndpoint?: string
+  logoutEndpoint?: string
   audience?: string
   redirectUri?: string
   scopes: string[]
@@ -146,11 +147,22 @@ export class AuthService<TIDToken = JWTIDToken> {
     return window.localStorage.getItem('auth') !== null
   }
 
-  async logout(): Promise<boolean> {
+  async logout(shouldEndSession: boolean = false): Promise<boolean> {
     this.removeItem('pkce')
     this.removeItem('auth')
-    window.location.reload()
-    return true
+    if (shouldEndSession) {
+      const { clientId, provider, logoutEndpoint, redirectUri } = this.props;
+      const query = {
+        client_id: clientId,
+        post_logout_redirect_uri: redirectUri
+      }
+      const url = `${logoutEndpoint || `${provider}/logout`}?${toUrlEncoded(query)}`
+      window.location.replace(url)
+      return true;
+    } else {
+      window.location.reload()
+      return true
+    }
   }
 
   async login(): Promise<void> {


### PR DESCRIPTION
We ran into a problem with "pending" sessions of a prior logged in user after logout. This relates to the fact that the `logout` call removes local auth infos only. So I added the possibility to end a users session when calling logout. You can configure the logout endpoint if you use a different or custom id provider.

Only works in "Single Application Logout" scenarios. Global logout with multiple applications is not considered now.
Reference: https://medium.com/@robert.broeckelmann/openid-connect-logout-eccc73df758f

Kind regards,
Tobias