### PR TITLE
Handle invalid refresh token responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-pkce",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Authenticate against generic OAuth2 using PKCE",
   "author": "Gardner Bickford <gardner@bickford.nz>",
   "license": "MIT",

--- a/src/AuthService.ts
+++ b/src/AuthService.ts
@@ -236,6 +236,10 @@ export class AuthService<TIDToken = JWTIDToken> {
       method: 'POST',
       body: toUrlEncoded(payload)
     })
+    if (isRefresh && !response.ok) {
+      await this.logout()
+      await this.login()
+    }
     this.removeItem('pkce')
     let json = await response.json()
     if (isRefresh && !json.refresh_token) {


### PR DESCRIPTION
Hello folks,

I face a problem with `autoRefresh` enabled. If the `tokenEndpoint` responds with non-success http status code, the response body is still stored in localStorage. The value is not a valid `AuthTokens` object and crashes the `jwt-decode` call. Since the token values are read from localStorage, the app won't work even when reloading the whole page. Only fix is to remove the 'auth' value from localStorage.

If the response from `tokenEndpoint` is http 400 e.g. if the refresh_token expired (see: OIDC API Doc for tokenEndpoint https://connect2id.com/products/server/docs/api/token#overview), the response body should not be stored. Instead, a full login cycle should be kicked off.

It's a little bit tricky to reproduce - I mocked the http request on the `tokenEndpoint` to the IDP (Keycloak in my case) with a Chrome Extension https://github.com/mukuljainx/Mokku This is the body I returned in the mock
```
{
	"error": "invalid_grant",
	"error_description": "Invalid refresh token"
}
```

The fix proposed in this PR will start a new login cycle.

Kind regards,
Tobias
