### PR TITLE
fix: convert "expires_in" to integer

### DIFF
--- a/src/AuthService.ts
+++ b/src/AuthService.ts
@@ -128,7 +128,7 @@ export class AuthService<TIDToken = JWTIDToken> {
   setAuthTokens(auth: AuthTokens): void {
     const { refreshSlack = 5 } = this.props
     const now = new Date().getTime()
-    auth.expires_at = now + (auth.expires_in + refreshSlack) * 1000
+    auth.expires_at = now + (+auth.expires_in + refreshSlack) * 1000
     window.localStorage.setItem('auth', JSON.stringify(auth))
   }
 


### PR DESCRIPTION
`expires_in` can be given as a string, causing string to number concatenation and incorrect `expires_at` calculation.
Fixed it by to converting it into a number, if it isn't already.