### PR TITLE
Added support for state parameter and bumped version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-pkce",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-oauth2-pkce",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Authenticate against generic OAuth2 using PKCE",
   "author": "Gardner Bickford <gardner@bickford.nz>",
   "license": "MIT",

--- a/src/AuthService.ts
+++ b/src/AuthService.ts
@@ -46,6 +46,10 @@ export interface TokenRequestBody {
   codeVerifier?: string
 }
 
+export interface AuthOptions {
+  state?: string;
+}
+
 export class AuthService<TIDToken = JWTIDToken> {
   props: AuthServiceProps
   timeout?: number
@@ -165,12 +169,12 @@ export class AuthService<TIDToken = JWTIDToken> {
     }
   }
 
-  async login(): Promise<void> {
-    this.authorize()
+  async login(options?: AuthOptions): Promise<void> {
+    this.authorize(options)
   }
 
   // this will do a full page reload and to to the OAuth2 provider's login page and then redirect back to redirectUri
-  authorize(): boolean {
+  authorize(options?: AuthOptions): boolean {
     const { clientId, provider, authorizeEndpoint, redirectUri, scopes, audience } = this.props
 
     const pkce = createPKCECodes()
@@ -186,7 +190,8 @@ export class AuthService<TIDToken = JWTIDToken> {
       redirectUri,
       ...(audience && { audience }),
       codeChallenge,
-      codeChallengeMethod: 'S256'
+      codeChallengeMethod: 'S256',
+      ...(options && { ...options })
     }
     // Responds with a 302 redirect
     const url = `${authorizeEndpoint || `${provider}/authorize`}?${toUrlEncoded(query)}`


### PR DESCRIPTION
Motivation:

I came across the need to send a value from the authorization request through to the authorization response.  Outlined [here](https://www.oauth.com/oauth2-servers/authorization/the-authorization-response/), using the state parameter is the correct way to send values from the request to the response.  This `state` parameter [helps mitigate CSRF attacks](https://auth0.com/docs/secure/attack-protection/state-parameters)

I changed the `authorize` and `login` functions to accept an optional state parameter.

Please note, I also bumped the package version as well.  `2.0.7` -> `2.0.8`